### PR TITLE
Сancel on creating css.map files

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -15,7 +15,7 @@ export function defaultInputOptions({ buildDirectory, tmpDir, sourcemap }) {
       mode: ["extract"],
       autoModules: (id) => id.includes(".module.css"),
       minimize: true,
-      sourceMap: true,
+      sourceMap: sourcemap,
     }),
     url({
       include: "**/*",


### PR DESCRIPTION
In a current moment plugin doesn't have mechanism for disabled css.map fiels. This patch fix it :slightly_smiling_face: