### PR TITLE
improve performance and fix regex reset .proxy.js imports

### DIFF
--- a/src/proxyImportResolver.js
+++ b/src/proxyImportResolver.js
@@ -1,6 +1,6 @@
 // https://github.com/pikapkg/snowpack/blob/master/plugins/plugin-webpack/plugins/proxy-import-resolve.js
 export function proxyImportResolver(source) {
-  const regex = /import.*['"].*\.(\w+)\.proxy\.js['"]/g;
+  const regex = /^import.*['"].*\.(\w+)\.proxy\.js['"][;\s]*$/mg;
   return source.replace(regex, (fullMatch, originalExt) => {
     // no JSON plugin loaded
     if (originalExt === "json") {


### PR DESCRIPTION
Hi, i improved performance of regex (start line with ^import); In my project, where I use vuetify, on file 'vuetify.css.proxy.js' it took more than 10 minutes ...
and i fixed (make it multiline "/mg") for scenarios when the import "...proxy.js" is not on the first line.